### PR TITLE
Add default locale to unit tests.

### DIFF
--- a/test/les6/Practicum6A/GameTest.java
+++ b/test/les6/Practicum6A/GameTest.java
@@ -4,6 +4,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
+
+import java.util.Locale;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class GameTest {
@@ -12,6 +15,7 @@ class GameTest {
 
     @BeforeEach
     public void init(){
+        Locale.setDefault(new Locale("NL"));
         ditJaar = LocalDate.now().getYear();
         game1JrOud = new Game("Mario Kart", ditJaar-1, 50.0);
     }

--- a/test/les6/Practicum6A/PersoonTest.java
+++ b/test/les6/Practicum6A/PersoonTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 
+import java.util.Locale;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class PersoonTest {
@@ -28,6 +30,7 @@ class PersoonTest {
 
     @BeforeEach
     public void init(){
+        Locale.setDefault(new Locale("NL"));
         ditJaar = LocalDate.now().getYear();
         koper = new Persoon("Eric de Koper",200.0);
         koperArm = new Persoon("Hans",36.0);


### PR DESCRIPTION
Several tests check for a formatted decimal value, this changes depending on your system settings as Dutch uses a comma as the decimal separator while many other locale settings use a period as the decimal separator, e.g. 35,99 vs 35.99.